### PR TITLE
mailto link in maintainer page not working

### DIFF
--- a/maintainer-guide.md
+++ b/maintainer-guide.md
@@ -50,7 +50,7 @@ If you want a way to chat more synchronously with folks working on PRs we will b
 
 To make sure that everyone can participate in the hackathon, we encourage project maintainers to tag a variety of issues that may or may not include quantum content, may or may not require Dev Ops skills, etc. We understand projects can be very targeted so if this is not possible that's totally fine! Our goal is to help connect eager and skilled contributors to your projects to help make the quantum open source ecosystem better 💖
 
-If you have any questions/comments/suggestions for this event we would love to hear from you, just send us an email at sarah@unitary.fund!
+If you have any questions/comments/suggestions for this event we would love to hear from you, just send us an email at [sarah@unitary.fund](mailto:sarah@unitary.fund?subject=[GitHub]%20Source%20Han%20Sans)!
 
 ## Helpful resources
 


### PR DESCRIPTION
sarah@unitary.fund is not a clickable link in the website on the [maintainer page](https://unitaryfund.github.io/unitaryhack/maintainer-guide.html) in the last line under "How to choose good issues". Hope my modification fixed that.