### PR TITLE
add banner linking to 2022 uhack

### DIFF
--- a/index.md
+++ b/index.md
@@ -10,6 +10,17 @@ title:
 .tg th{background-color:yellow;border-style:none;border-width:1px;
   overflow:hidden;padding:5px 5px;word-break:normal;text-align:center;font-size:large;}
 </style>
+
+<table class="tg">
+<tbody>
+  <tr>
+    <th colspan="2">Check out unitaryHACK 2022 at <a href="https://unitaryhack.dev">https://unitaryhack.dev</a> and its Github Repo <a href="https://github.com/unitaryfund/unitaryhackdev">here</a>.</th>
+  </tr>
+</tbody>
+</table>
+
+<br>
+
 <table class="tg">
 <tbody>
   <tr>


### PR DESCRIPTION
Partially addresses https://github.com/unitaryfund/unitaryhack/issues/58.

**This change is partially untested.** I cannot bring up this site locally due to some ruby problems I'm having on my computer. I tested this by editing the HTML of the actual website in the browser to generate the following screenshots.

| before | after |
| --- | --- |
| <img width="756" alt="Screen Shot 2022-06-01 at 7 51 24 AM" src="https://user-images.githubusercontent.com/12703123/171434009-656f5a9c-8784-42d7-85a9-168ec38145b0.png"> | <img width="756" alt="Screen Shot 2022-06-01 at 7 51 12 AM" src="https://user-images.githubusercontent.com/12703123/171434048-9631a887-79ca-4342-8ba7-93be2692fb01.png"> |



Nathan, if you'd like to give me access to the UF domains, I'd be happy to put this website on a subdomain as well as mentioned in https://github.com/unitaryfund/unitaryhack/issues/58.